### PR TITLE
Fix undefined \tightlist error in LaTeX template

### DIFF
--- a/.github/workflows/markdown-to-pdf.yaml
+++ b/.github/workflows/markdown-to-pdf.yaml
@@ -61,6 +61,9 @@ jobs:
           \renewcommand{\normalsize}{\@setfontsize\normalsize{10.5pt}{14pt}}
           \makeatother
 
+          % Define \tightlist used by pandoc for compact lists
+          \providecommand{\tightlist}{\setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+
           % Better lists that look more like GitHub
           \setlist[itemize]{leftmargin=*, itemsep=3pt}
           


### PR DESCRIPTION
## Summary

- Pandoc emits `\tightlist` when converting compact markdown lists (lists without blank lines between items)
- The custom LaTeX template was missing this command definition, causing xelatex to fail with `! Undefined control sequence` (exit code 43)
- Added `\providecommand{\tightlist}` to the template, which is the standard fix pandoc's own default template uses

## Test plan

- [ ] Trigger the workflow after merging (push to `readme.md` or use workflow_dispatch) and verify the PDF is generated successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)