### PR TITLE
Trigger workflow on changes to the workflow file itself

### DIFF
--- a/.github/workflows/markdown-to-pdf.yaml
+++ b/.github/workflows/markdown-to-pdf.yaml
@@ -5,6 +5,7 @@ on:
     branches: [ main, master ]
     paths:
       - 'readme.md'
+      - '.github/workflows/markdown-to-pdf.yaml'
   workflow_dispatch:
     inputs:
       debug_enabled:


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/markdown-to-pdf.yaml` to the path triggers so that edits to the workflow file also kick off a build
- Without this, workflow changes (like the \tightlist fix in #4) can't be tested without also touching `readme.md`

## Test plan

- [ ] Merge this PR and verify the workflow triggers on the merge commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)